### PR TITLE
Improve crash email handling

### DIFF
--- a/pscore.py
+++ b/pscore.py
@@ -7,9 +7,7 @@ from string import ascii_letters, punctuation, whitespace
 
 
 def init_config(config_path):
-    """Reads config file to global 'config' dict. Many frequently-used variables are copied to their own globals for convenince.
-
-    Returns SMTP config dict for crash handling."""
+    """Reads config file to global 'config' dict. Many frequently-used variables are copied to their own globals for convenince."""
     global CONFIG
     global PC_API_URL
     global PC_API_CRED
@@ -67,8 +65,7 @@ def init_config(config_path):
     CNXN = pyodbc.connect(CONFIG['pc_database_string'])
     CURSOR = CNXN.cursor()
 
-    # Config dicts
-    smtp_config = CONFIG['smtp']
+    # Misc configs
     ERROR_STRINGS = CONFIG['error_strings']
 
     # Print a test of connections
@@ -77,8 +74,6 @@ def init_config(config_path):
     print(r.text)
     r.raise_for_status()
     print(CNXN.getinfo(pyodbc.SQL_DATABASE_NAME))
-
-    return smtp_config
 
 
 def de_init():

--- a/sync_ondemand.py
+++ b/sync_ondemand.py
@@ -1,10 +1,6 @@
 import sys
-import requests
 import json
-import copy
 import datetime
-import pyodbc
-import xml.etree.ElementTree as ET
 import traceback
 import smtplib
 from email.mime.text import MIMEText
@@ -12,16 +8,15 @@ import pscore
 
 
 # Attempt a sync; send failure email with traceback if error.
+# Name of configuration is file passed via command-line
 try:
     print('Start sync at ' + str(datetime.datetime.now()))
-    # Name of configuration file passed via command-line
-    smtp_config = pscore.init_config(sys.argv[1])
-    # smtp_config = pscore.init_config('config_dev.json') # For debugging
+    pscore.init_config(sys.argv[1])
     pscore.main_sync()
-    pscore.de_init()
     print('Done at ' + str(datetime.datetime.now()))
 except Exception as e:
-    # Send a failure email with traceback on exceptions
+    with open(sys.argv[1]) as config_file:
+        smtp_config = json.load(config_file)['smtp']
     print('Exception at ' + str(datetime.datetime.now()) +
           '! Check notification email.')
     msg = MIMEText('Sync failed at ' + str(datetime.datetime.now()) + '\n\nError: '


### PR DESCRIPTION
smtp_config is now loaded at exception time within sync_ondemand instead of pscore. This means that fewer crashes will be able to break the catch block and skip sending email.