### PR TITLE
Add MS Teams Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ An integration between PowerCampus and Slate (hence the name). Admissions applic
 [Field documentation](PowerSlate%20Integration%20Fields.docx)
 
 ## Requirements
-Python 3.9+ is required, along with a few packages available via pip. There are no known issues between different package versions.
+Python 3.9+ is required, along with a few packages available via pip. There are no known issues between different package versions. 
+(Pymsteams-0.2.2) For Teams Alerts
 
 ## Usage
 ### Configuration

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ An integration between PowerCampus and Slate (hence the name). Admissions applic
 
 ## Requirements
 Python 3.9+ is required, along with a few packages available via pip. There are no known issues between different package versions. 
-(Pymsteams-0.2.2) For Teams Alerts
+### Optional Packages
+ - O365 for error emails sent via Exchange Online.
+ - Pymsteams-0.2.2 for error alerts via Teams
 
 ## Usage
 ### Configuration

--- a/config_sample.json
+++ b/config_sample.json
@@ -96,6 +96,11 @@
 			"password": "astrongpassword"
 		}
 	},
+	"teams": {
+		"enabled": false,
+		"webHookURL" : "[YOUR TEAMS WEBHOOK GOES HERE]",
+		"title" : "PowerSlate [Production] Alert"
+	},
 	"scheduled_actions": {
 		"enabled": false,
 		"slate_get": {

--- a/sync_ondemand.py
+++ b/sync_ondemand.py
@@ -28,6 +28,7 @@ if __name__ == "__main__":
         with open(sys.argv[1]) as config_file:
             config = json.load(config_file)
             email_config = config["email"]
+            teams_config = config["teams"]
             if current_record:
                 slate_domain = urlparse(config["slate_query_apps"]["url"]).netloc
                 current_record_link = (
@@ -51,6 +52,14 @@ if __name__ == "__main__":
             + "\nCurrent Record: "
             + current_record_link
         )
+
+        if teams_config["enabled"] == True:
+            import pymsteams
+            teamsMsg = pymsteams.connectorcard(teams_config["webHookURL"])
+            teamsMsg.text(body)
+            teamsMsg.title(teams_config["title"])
+            teamsMsg.addLinkButton("Open Slate Record",current_record_link)
+            teamsMsg.send()
 
         if email_config["method"] == "o365":
             from O365 import Account


### PR DESCRIPTION
If enabled in the config, the same error message that usually gets emailed will now be sent to the Teams webhook.